### PR TITLE
「TestRunnerの拡張」セクション内の変換ミス修正

### DIFF
--- a/src/extending-phpunit.rst
+++ b/src/extending-phpunit.rst
@@ -330,7 +330,7 @@ PHPUnit |version| は TestRunner エクステンションをサポートして�
 PHPUnit の XML 設定ファイルでエクステンションを組み込む方法については
 :ref:`appendixes.configuration.extensions` を参照ください。
 
-エクステンションでフックを組み込めるイベントはインターフェイスとして航海されており、
+エクステンションでフックを組み込めるイベントはインターフェイスとして公開されており、
 これをエクステンションが実装する必要があります。
 PHPUnit |version| で使えるイベントの一覧を
 :ref:`extending-phpunit.hooks` に示します。


### PR DESCRIPTION
「公開」とされるべきところが「航海」となっている変換ミスがありました